### PR TITLE
Export Single Row Signal as Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Minimax Simulator
 =================
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/SRAhub/MinimaxSimulator/blob/develop/LICENSE.txt) &nbsp; [![Latest release](http://img.shields.io/github/release/SRAhub/MinimaxSimulator.svg)](https://github.com/SRAhub/MinimaxSimulator/releases)	&nbsp; [![Travis CI Build Status](https://travis-ci.org/SRAhub/MinimaxSimulator.png?branch=master)](https://travis-ci.org/SRAhub/MinimaxSimulator) &nbsp; 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/luhsra/MinimaxSimulator/blob/develop/LICENSE.txt) &nbsp; [![Latest release](http://img.shields.io/github/release/luhsra/MinimaxSimulator.svg)](https://github.com/luhsra/MinimaxSimulator/releases)	&nbsp; [![Travis CI Build Status](https://travis-ci.org/luhsra/MinimaxSimulator.png?branch=master)](https://travis-ci.org/luhsra/MinimaxSimulator) &nbsp; 
 
 Minimax Simulator is a platform independent GUI-based Minimax simulator written in Java.
 
@@ -80,7 +80,7 @@ Note that usually you can speed up the process by submitting a pull request prov
 
 <a name="changelog"></a> Change Log
 ---------------------------------
-See [Change Log](https://srahub.github.io/MinimaxSimulator/changelog.html)
+See [Change Log](https://luhsra.github.io/MinimaxSimulator/changelog.html)
 
 <a name="license"></a> License
 ------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                 </executions>
             </plugin>
             <plugin>
-		        <groupId>org.apache.maven.plugins</groupId>
+		 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
@@ -171,6 +171,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>default-jar</id>

--- a/src/main/java/de/uni_hannover/sra/minimax_simulator/io/exporter/json/SignalJsonExporter.java
+++ b/src/main/java/de/uni_hannover/sra/minimax_simulator/io/exporter/json/SignalJsonExporter.java
@@ -73,6 +73,7 @@ class SignalJsonExporter {
             rowObj.put("breakpoint", true);
         }
 
+        rowObj.put("signal", new JSONArray());                // add empty JSONArray as base for row signals
         for (Entry<String, SignalValue> entry : row.getSignalValues().entrySet()) {
             SignalValue value = entry.getValue();
 


### PR DESCRIPTION
This PR fixes #40. Row signals are always exported as an array now; even if they contain only one signal.

Additionally, I updated some links in the README that still linked to the old repository and added a version number for the maven-jar-plugin in the POM file.