### PR TITLE
Bump guava from 26.0-jre to 30.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
+            <version>30.0-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
GitHub will have notified you earlier, guava 26 has a security vulnerability.

The dependabot sucks though, and recommends to bump to the still vulnerable version `29.0-jre`.
Please merge this instead of #60.

> patched versions: 30.0-jre

https://github.com/advisories/GHSA-5mg8-w23w-74h3